### PR TITLE
Fix middleman-blog incompatibility

### DIFF
--- a/lib/contentful/middleman-pages/extension.rb
+++ b/lib/contentful/middleman-pages/extension.rb
@@ -84,6 +84,7 @@ module Contentful
           resource.extend ResourceInstanceMethods
           resource.data = entry_data
           resource.add_metadata locals: entry_data
+          resource.add_metadata page: entry_data
 
           if (index = is_existing_resource?(resource, new_resources_list))
             new_resources_list[index] = resource


### PR DESCRIPTION
Currently this gem is actually incompatible with middleman-blog under version 4. Category pages break as well as a bunch of other stuff because metadata uses a different reference. This gem uses adds the `:data` metadata attribute, but middleman-blog (under v4) demands the reference `:page` -> [see here](https://github.com/middleman/middleman-blog/blob/d78ee928dd3a98cff506a8b971fb1a56190367b4/lib/middleman-blog/custom_pages.rb#L30) for an example.
